### PR TITLE
Proposal: a sharing-friendly demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
 
     <script>
       window.onload = function() {
-
         var inp = document.querySelector('#username'),
             frm = document.querySelector('#create-card'),
             output = document.querySelector('#cards');
@@ -184,8 +183,6 @@
     </template>
 
     <script>
-
-
       var url = 'https://api.github.com/users/',
           doc = document.currentScript.ownerDocument,
           XgithubProto = Object.create(HTMLElement.prototype);


### PR DESCRIPTION
Basically, the demo page loads a user's card if the "user" parameter is passed, otherwise it defaults to your card (example.png). If the "Show" button is clicked, the page loads user's card and rewrites the URL.

I think this might help your awesome work to spread :-)

![github-card-0-r](https://cloud.githubusercontent.com/assets/941963/3275426/51f14806-f33b-11e3-9038-741ce7d7d410.png)
![github-card-1-r](https://cloud.githubusercontent.com/assets/941963/3275433/5a49aa0c-f33b-11e3-8e98-99c707fd8c40.png)
